### PR TITLE
set Locale.ENGLISH for DateFormat Tests

### DIFF
--- a/src/test/java/com/github/javafaker/service/FakeValuesServiceTest.java
+++ b/src/test/java/com/github/javafaker/service/FakeValuesServiceTest.java
@@ -234,7 +234,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
 
     @Test
     public void futureDateExpression() throws ParseException {
-        SimpleDateFormat dateFormat = new SimpleDateFormat( "EEE MMM dd HH:mm:ss z yyyy" );
+        SimpleDateFormat dateFormat = new SimpleDateFormat( "EEE MMM dd HH:mm:ss z yyyy", Locale.ENGLISH  );
 
         Date now = new Date();
         Date nowPlus10Days = new Date( now.getTime() + MILLIS_IN_A_DAY * 10 );
@@ -247,7 +247,7 @@ public class FakeValuesServiceTest extends AbstractFakerTest {
 
     @Test
     public void pastDateExpression() throws ParseException {
-        SimpleDateFormat dateFormat = new SimpleDateFormat( "EEE MMM dd HH:mm:ss z yyyy" );
+        SimpleDateFormat dateFormat = new SimpleDateFormat( "EEE MMM dd HH:mm:ss z yyyy", Locale.ENGLISH );
 
         Date now = new Date();
         Date nowMinus5Hours = new Date( now.getTime() - MILLIS_IN_AN_HOUR * 5 );


### PR DESCRIPTION
- run in other, e.g. Locale.GERMAN, fails